### PR TITLE
Arreglando comillas de inserción mal colocodas

### DIFF
--- a/ejercicios/SamuelCarmonaSoria/EjerciciosTema4.md
+++ b/ejercicios/SamuelCarmonaSoria/EjerciciosTema4.md
@@ -133,7 +133,8 @@ Y si queremos borrarlo:
 Ahora, vamos a instalar una imagen que incluya MongoDB:
 
 Seguimos el mismo procedimiento usado previamente:
- ```sudo docker pull mongo
+ ```
+ sudo docker pull mongo
 sudo docker run -i -t mongo
 sudo docker ps -a
 ```


### PR DESCRIPTION
En un lugar, tenía que colocar un caracter de retorno de línea, porque las comillas ``` de inserción de código no cerraban bien, y a partir de ahí se veía mal el documento.